### PR TITLE
Reuse fewest match candidates

### DIFF
--- a/python/swordsmith/swordsmith.py
+++ b/python/swordsmith/swordsmith.py
@@ -372,17 +372,23 @@ class Filler(ABC):
     def fewest_matches(crossword, wordlist):
         """Finds the slot that has the fewest possible matches, this is probably the best next place to look."""
         fewest_matches_slot = None
-        fewest_matches = len(wordlist.words) + 1
+        fewest_matches_collection = None
+        fewest_matches_count = len(wordlist.words) + 1
 
         for slot in crossword.words:
             word = crossword.words[slot]
             if Crossword.is_word_filled(word):
                 continue
-            matches = len(wordlist.get_matches(word))
-            if matches < fewest_matches:
-                fewest_matches = matches
+            matches = wordlist.get_matches(word)
+            match_count = len(matches)
+            if match_count < fewest_matches_count:
+                fewest_matches_count = match_count
                 fewest_matches_slot = slot
-        return fewest_matches_slot, fewest_matches
+                fewest_matches_collection = matches
+        if fewest_matches_collection is None:
+            fewest_matches_collection = ()
+
+        return fewest_matches_slot, fewest_matches_collection
     
     @staticmethod
     def minlook(crossword, wordlist, slot, matches, k):
@@ -433,18 +439,19 @@ class DFSFiller(Filler):
             return True
 
         # choose slot with fewest matches
-        slot, num_matches = Filler.fewest_matches(crossword, wordlist)
+        slot, matches = Filler.fewest_matches(crossword, wordlist)
+
+        num_matches = len(matches)
 
         # if some slot has zero matches, fail
         if num_matches == 0:
             return False
-        
+
         # iterate through all possible matches in the fewest-match slot
         previous_word = crossword.words[slot]
-        matches = wordlist.get_matches(crossword.words[slot])
+        matches = list(matches)
 
         # randomly shuffle matches
-        matches = list(matches)
         shuffle(matches)
 
         for match in matches:
@@ -481,18 +488,19 @@ class DFSBackjumpFiller(Filler):
             return True, None
 
         # choose slot with fewest matches
-        slot, num_matches = Filler.fewest_matches(crossword, wordlist)
+        slot, matches = Filler.fewest_matches(crossword, wordlist)
+
+        num_matches = len(matches)
 
         # if some slot has zero matches, fail
         if num_matches == 0:
             return False, slot
-        
+
         # iterate through all possible matches in the fewest-match slot
         previous_word = crossword.words[slot]
-        matches = wordlist.get_matches(crossword.words[slot])
+        matches = list(matches)
 
         # randomly shuffle matches
-        matches = list(matches)
         shuffle(matches)
         
         for match in matches:
@@ -534,18 +542,19 @@ class MinlookFiller(Filler):
             return True
 
         # choose slot with fewest matches
-        slot, num_matches = Filler.fewest_matches(crossword, wordlist)
+        slot, matches = Filler.fewest_matches(crossword, wordlist)
+
+        num_matches = len(matches)
 
         # if some slot has zero matches, fail
         if num_matches == 0:
             return False
-        
+
         # iterate through all possible matches in the fewest-match slot
         previous_word = crossword.words[slot]
-        matches = wordlist.get_matches(crossword.words[slot])
+        matches = list(matches)
 
         # randomly shuffle matches
-        matches = list(matches)
         shuffle(matches)
 
         while matches:
@@ -596,18 +605,19 @@ class MinlookBackjumpFiller(Filler):
             return True, None
 
         # choose slot with fewest matches
-        slot, num_matches = Filler.fewest_matches(crossword, wordlist)
+        slot, matches = Filler.fewest_matches(crossword, wordlist)
+
+        num_matches = len(matches)
 
         # if some slot has zero matches, fail
         if num_matches == 0:
             return False, slot
-        
+
         # iterate through all possible matches in the fewest-match slot
         previous_word = crossword.words[slot]
-        matches = wordlist.get_matches(crossword.words[slot])
+        matches = list(matches)
 
         # randomly shuffle matches
-        matches = list(matches)
         shuffle(matches)
 
         while matches:

--- a/python/tests/test_swordsmith.py
+++ b/python/tests/test_swordsmith.py
@@ -1,13 +1,17 @@
 import sys
 import unittest
+from pathlib import Path
 
-sys.path.append('../swordsmith')
+
+TEST_DIR = Path(__file__).resolve().parent
+SWORDSMITH_DIR = (TEST_DIR / ".." / "swordsmith").resolve()
+sys.path.append(str(SWORDSMITH_DIR))
 
 import swordsmith as sw
 
-GRID_5x = '../swordsmith/grid/5x.txt'
-GRID_15x = '../swordsmith/grid/15xcommon.txt'
-WORDLIST = '../swordsmith/wordlist/spreadthewordlist.dict'
+GRID_5x = SWORDSMITH_DIR / "grid" / "5x.txt"
+GRID_15x = SWORDSMITH_DIR / "grid" / "15xcommon.txt"
+WORDLIST = SWORDSMITH_DIR / "wordlist" / "spreadthewordlist.dict"
 
 class Test5xDFS(unittest.TestCase):
     def runTest(self):
@@ -89,4 +93,5 @@ class Test15xMinlookBackjump(unittest.TestCase):
         filler.fill(crossword, wordlist, animate=False)
         self.assertTrue(crossword.is_filled())
 
-unittest.main()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `Filler.fewest_matches` return both the slot and its cached match collection
- update all fillers to reuse the precomputed matches while preserving shuffle behaviour
- fix the Python tests by resolving resource paths relative to the repository and guarding the unittest entry point

## Testing
- PYTHONPATH=python:python/swordsmith pytest python/tests

------
https://chatgpt.com/codex/tasks/task_e_68cb2393cbe48326a67520bd79ed4b85