### PR TITLE
Ensure Wordlist get_matches returns independent sets

### DIFF
--- a/python/swordsmith/swordsmith.py
+++ b/python/swordsmith/swordsmith.py
@@ -301,16 +301,19 @@ class Wordlist:
     
     def get_matches(self, pattern):
         if pattern in self.pattern_matches:
-            return self.pattern_matches[pattern]
-        
+            return set(self.pattern_matches[pattern])
+
         length = len(pattern)
         indices = [self.indices[length][i][letter] for i, letter in enumerate(pattern) if letter != EMPTY]
         if indices:
             matches = set.intersection(*indices)
         else:
-            matches = self.lengths[length]
+            matches = set(self.lengths[length])
 
-        return matches
+        matches = set(matches)
+        self.pattern_matches[pattern] = frozenset(matches)
+
+        return set(self.pattern_matches[pattern])
 
 
 class Filler(ABC):


### PR DESCRIPTION
## Summary
- cache Wordlist pattern matches as frozensets to prevent external mutation
- return a fresh set for both cached and newly-computed results to preserve callers' expectations

## Testing
- python3 swordsmith -g 15xcommon -s mlb


------
https://chatgpt.com/codex/tasks/task_e_68cb20f6707c832695c1f8830040b73d