### PR TITLE
enforce rotational symmetry checks

### DIFF
--- a/python/tests/test_swordsmith.py
+++ b/python/tests/test_swordsmith.py
@@ -32,6 +32,57 @@ class Test5xDFS(unittest.TestCase):
         self.assertTrue(crossword.is_filled())
 
 
+class TestBlockPlacementSymmetry(unittest.TestCase):
+    def runTest(self) -> None:
+        crossword = sw.AmericanCrossword(3, 3)
+        crossword.put_block(0, 1)
+
+        self.assertEqual(crossword.grid[0][1], sw.BLOCK)
+        self.assertEqual(crossword.grid[2][1], sw.BLOCK)
+
+
+class TestFromGridSymmetryValidation(unittest.TestCase):
+    def runTest(self) -> None:
+        asym_grid = [
+            [sw.BLOCK, sw.EMPTY],
+            [sw.EMPTY, sw.EMPTY],
+        ]
+
+        with self.assertRaises(ValueError):
+            sw.AmericanCrossword.from_grid(asym_grid)
+
+
+class TestWildcardLayoutSymmetry(unittest.TestCase):
+    def runTest(self) -> None:
+        grid = [
+            ['+', sw.BLOCK, '+', sw.EMPTY],
+            [sw.EMPTY, sw.EMPTY, sw.EMPTY, '+'],
+            [sw.EMPTY, sw.EMPTY, sw.EMPTY, sw.EMPTY],
+            [sw.EMPTY, '+', sw.BLOCK, '+'],
+        ]
+
+        layouts = list(sw.iterate_wildcard_layouts(grid))
+        self.assertTrue(layouts, msg='No layouts were generated from wildcard grid')
+
+        for layout in layouts:
+            rows = len(layout)
+            cols = len(layout[0]) if rows else 0
+            for row_index in range(rows):
+                for col_index in range(cols):
+                    if layout[row_index][col_index] == sw.BLOCK:
+                        partner_row = rows - 1 - row_index
+                        partner_col = cols - 1 - col_index
+                        self.assertEqual(
+                            layout[partner_row][partner_col],
+                            sw.BLOCK,
+                            msg=(
+                                'Asymmetric layout emitted: '
+                                f'{(row_index, col_index)} lacks partner '
+                                f'at {(partner_row, partner_col)}'
+                            ),
+                        )
+
+
 class Test5xDFSBackjump(unittest.TestCase):
     def runTest(self) -> None:
         grid = sw.read_grid(GRID_5X)


### PR DESCRIPTION
## Summary
- add a rotational-symmetry flag to `AmericanCrossword`, mirror block placement automatically, and reject conflicting grids during construction【F:python/swordsmith/swordsmith.py†L113-L200】
- guard wildcard layouts and CLI runs with symmetry validation while allowing an opt-out switch for asymmetric experiments【F:python/swordsmith/swordsmith.py†L721-L919】
- extend the test suite to cover mirrored block placement, asymmetric grid rejection, and wildcard layout filtering【F:python/tests/test_swordsmith.py†L35-L84】

## Testing
- `python3 swordsmith/swordsmith.py -g 15xcommon -s mlb`【7122ee†L1-L61】
- `PYTHONPATH=../swordsmith python3 test_swordsmith.py`【c01736†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68cc548c7f08832697a123ea8fc631de