### PR TITLE
enforce minimum slot length

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -20,12 +20,17 @@ Using any of these optional command line flags:
 | --k K | -k | k constant for minlook |
 | --strategy [dfs dfsb minlook mlb] | -s | which filling algorithm to run |
 | --animate | -a | whether to animate grid filling |
+| --min-word-length MIN_WORD_LENGTH | - | minimum allowed slot length (default: 3) |
 
 For example:
 
 ```
 python3 swordsmith -w spreadthewordlist.dict -g 7xopen.txt -a
 ```
+
+The engine now enforces a minimum slot length of three cells. Use `--min-word-length`
+to override the default, and note that grids violating the configured threshold will
+raise a `ValueError` during construction so you can correct issues immediately.
 
 ---
 
@@ -77,15 +82,18 @@ Represents a special case of the crossword that consists of a two-dimensional gr
 
 ### Fields
 - `rows`
-	- Number of rows in the grid
+        - Number of rows in the grid
 - `cols`
-	- Number of columns in the grid
+        - Number of columns in the grid
 - `grid`
-	- `rows` by `cols` array of characters representing the letters in each square of the grid
+        - `rows` by `cols` array of characters representing the letters in each square of the grid
+- `min_word_length`
+        - Minimum allowable length for any across or down slot (defaults to 3, never less than 1)
 
 ### Class Methods
-- `from_grid(cls, grid)`
-	- Generates a crossword from 2D array of characters
+- `from_grid(cls, grid, min_word_length=3, all_checked=False)`
+        - Generates a crossword from 2D array of characters and enforces the minimum slot length
+        - Raises `ValueError` when any across or down run is shorter than `min_word_length`
 
 ### Static Methods
 - `is_across_slot(slot)`
@@ -103,9 +111,10 @@ Represents a special case of the crossword that consists of a two-dimensional gr
 - `__generate_grid_from_slots(self)`
     - Processes `slots` to refresh the grid array
     - Called whenever the grid is about to be printed, in case the contents of the slots have changed
-- `__generate_slots_from_grid(self)`
-	- Processes `grid` array to generate the across and down slots
-	- Called whenever grid shape changes
+- `__generate_slots_from_grid(self, all_checked=False)`
+        - Processes `grid` array to generate the across and down slots
+        - When `all_checked` is `False`, raises `ValueError` if any slot is shorter than `min_word_length`
+        - Called whenever grid shape changes
 
 ---
 

--- a/python/tests/test_swordsmith.py
+++ b/python/tests/test_swordsmith.py
@@ -20,6 +20,47 @@ GRID_5X_OPEN_PLUS = SWORDSMITH_DIR / "grid" / "5xopenplus.txt"
 GRID_15X = SWORDSMITH_DIR / "grid" / "15xcommon.txt"
 WORDLIST = SWORDSMITH_DIR / "wordlist" / "spreadthewordlist.dict"
 
+
+class TestMinWordLengthEnforcement(unittest.TestCase):
+    def test_two_letter_run_raises(self) -> None:
+        grid = [
+            ".. ",
+            ".. ",
+            "   ",
+        ]
+
+        with self.assertRaises(ValueError) as exc_info:
+            sw.AmericanCrossword.from_grid(grid, min_word_length=3)
+
+        self.assertIn("(0, 0)", str(exc_info.exception))
+
+    def test_wildcard_respects_min_length(self) -> None:
+        grid = [
+            "+. ",
+            "...",
+            " .+",
+        ]
+
+        all_layouts = list(sw.iterate_wildcard_layouts(grid, min_word_length=1))
+        filtered_layouts = list(sw.iterate_wildcard_layouts(grid, min_word_length=3))
+
+        self.assertGreater(len(all_layouts), len(filtered_layouts))
+
+        for layout in filtered_layouts:
+            sw.AmericanCrossword.from_grid(layout, min_word_length=3)
+
+    def test_valid_grid_constructs(self) -> None:
+        grid = [
+            "...",
+            "...",
+            "...",
+        ]
+
+        crossword = sw.AmericanCrossword.from_grid(grid, min_word_length=3)
+        self.assertEqual(crossword.rows, 3)
+        self.assertTrue(all(len(slot) >= 3 for slot in crossword.slots))
+
+
 class Test5xDFS(unittest.TestCase):
     def runTest(self) -> None:
         grid = sw.read_grid(GRID_5X)


### PR DESCRIPTION
## Summary
- enforce a configurable `min_word_length` when constructing American crosswords, normalizing incoming grids and failing fast on undersized runs【F:python/swordsmith/swordsmith.py†L112-L153】【F:python/swordsmith/swordsmith.py†L244-L295】
- roll back invalid block placements, filter wildcard layouts, and expose the minimum slot length through the CLI to prevent propagating illegal states【F:python/swordsmith/swordsmith.py†L200-L230】【F:python/swordsmith/swordsmith.py†L697-L897】
- document the new behaviour and add regression tests covering invalid grids and wildcard pruning【F:python/tests/test_swordsmith.py†L24-L61】【F:python/README.md†L15-L117】

## Testing
- `python3 swordsmith -g 15xcommon -s mlb`【36fe70†L1-L46】
- `PYTHONPATH=../swordsmith python3 test_swordsmith.py`【0a9629†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68cc548e3d9c83269909c87b8df74020